### PR TITLE
AppContext.BaseDirectory is null on some platforms, Xamarin.Android f…

### DIFF
--- a/NativeLibraryLoader/PathResolver.cs
+++ b/NativeLibraryLoader/PathResolver.cs
@@ -40,7 +40,10 @@ namespace NativeLibraryLoader
         /// <returns>An enumerator yielding load targets.</returns>
         public override IEnumerable<string> EnumeratePossibleLibraryLoadTargets(string name)
         {
-            yield return Path.Combine(AppContext.BaseDirectory, name);
+            if (!string.IsNullOrEmpty(AppContext.BaseDirectory))
+            {
+                yield return Path.Combine(AppContext.BaseDirectory, name);
+            }
             yield return name;
             if (TryLocateNativeAssetFromDeps(name, out string appLocalNativePath, out string depsResolvedPath))
             {


### PR DESCRIPTION
Fixes #8 
Just added a check for nullorempty before use. Originally i just null checked but empty is the same as the following yield so makes sense to exclude it