### PR TITLE
Allow native library dependencies to be loaded from nuget runtime folders

### DIFF
--- a/NativeLibraryLoader/Kernel32.cs
+++ b/NativeLibraryLoader/Kernel32.cs
@@ -7,6 +7,8 @@ namespace NativeLibraryLoader
     {
         [DllImport("kernel32")]
         public static extern IntPtr LoadLibrary(string fileName);
+        [DllImport("kernel32")]
+        public static extern bool SetDllDirectory(string fileName);
 
         [DllImport("kernel32")]
         public static extern IntPtr GetProcAddress(IntPtr module, string procName);

--- a/NativeLibraryLoader/LibraryLoader.cs
+++ b/NativeLibraryLoader/LibraryLoader.cs
@@ -193,6 +193,11 @@ namespace NativeLibraryLoader
 
             protected override IntPtr CoreLoadNativeLibrary(string name)
             {
+                var libraryPath = Path.GetDirectoryName(name);
+                if (!string.IsNullOrEmpty(libraryPath))
+                {
+                    Kernel32.SetDllDirectory(libraryPath);
+                }
                 return Kernel32.LoadLibrary(name);
             }
         }

--- a/NativeLibraryLoader/NativeLibraryLoader.csproj
+++ b/NativeLibraryLoader/NativeLibraryLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>1.0.10</PackageVersion>
+    <PackageVersion>1.0.11</PackageVersion>
     <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Fixes #10 
I have written a test but as its a thrid party Nuget thats not in the open I can't submit it with it. It's a fairly simple change however.
Unless you know of any nuget's with native runtime libraries that have dependencies in the same folder....