### PR TITLE
Update Microsoft.Extensions.DependencyModel to 3.0.0

### DIFF
--- a/NativeLibraryLoader/NativeLibraryLoader.csproj
+++ b/NativeLibraryLoader/NativeLibraryLoader.csproj
@@ -11,6 +11,7 @@
     <DocumentationFile>bin/NativeLibraryLoader.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I got multiple NuGet warnings regarding package downgrades because of the low version of `Microsoft.Extensions.DependencyModel`, so I decided to update the package and I had to additionally include `Microsoft.DotNet.PlatformAbstractions` explicitly for it compile.