### PR TITLE
Load libSystem instead of libdl on macOS

### DIFF
--- a/NativeLibraryLoader/LibSystem.cs
+++ b/NativeLibraryLoader/LibSystem.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace NativeLibraryLoader
+{
+    internal static class LibSystem
+    {
+        private const string LibName = "libSystem.dylib";
+
+        public const int RTLD_NOW = 0x002;
+
+        [DllImport(LibName)]
+        public static extern IntPtr dlopen(string fileName, int flags);
+
+        [DllImport(LibName)]
+        public static extern IntPtr dlsym(IntPtr handle, string name);
+
+        [DllImport(LibName)]
+        public static extern int dlclose(IntPtr handle);
+
+        [DllImport(LibName)]
+        public static extern string dlerror();
+    }
+}

--- a/NativeLibraryLoader/LibraryLoader.cs
+++ b/NativeLibraryLoader/LibraryLoader.cs
@@ -171,9 +171,13 @@ namespace NativeLibraryLoader
             {
                 return new Win32LibraryLoader();
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return new UnixLibraryLoader();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return new OSXLibraryLoader();
             }
 
             throw new PlatformNotSupportedException("This platform cannot load native libraries.");
@@ -212,6 +216,24 @@ namespace NativeLibraryLoader
             protected override IntPtr CoreLoadNativeLibrary(string name)
             {
                 return Libdl.dlopen(name, Libdl.RTLD_NOW);
+            }
+        }
+
+        private class OSXLibraryLoader : LibraryLoader
+        {
+            protected override void CoreFreeNativeLibrary(IntPtr handle)
+            {
+                LibSystem.dlclose(handle);
+            }
+
+            protected override IntPtr CoreLoadFunctionPointer(IntPtr handle, string functionName)
+            {
+                return LibSystem.dlsym(handle, functionName);
+            }
+
+            protected override IntPtr CoreLoadNativeLibrary(string name)
+            {
+                return LibSystem.dlopen(name, LibSystem.RTLD_NOW);
             }
         }
     }


### PR DESCRIPTION
For further discussion, see: https://github.com/dotnet/runtime/issues/32852

tl;dr: We've recently encountered an issue where libdl.dylib can't be loaded on macOS <10.14.6. In order to fix this at least until .NET 5, we can load libSystem.dylib directly (which libcoreclr is linked against).

I have **not tested this**. Though the changes involve a copy-paste of Libdl.cs and a branch for the OSX scenario. Let me know of a system call I can make from libSystem.dylib if you'd like me to add a test for it.